### PR TITLE
typo correction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Wrap a React component in `collect` to have Recollect update the component when 
 
 ```jsx
 import React from 'react';
-import { collect } from 'react-recollect';
+import { store, collect } from 'react-recollect';
 import Task from './Task';
 
-const TaskList = ({ store ) => (
+const TaskList = () => (
   <div>
     {store.tasks.map(task => (
       <Task key={task.id} task={task} />


### PR DESCRIPTION
Hi 😃,

Just followed your example at codeSandbox and realized that you don't need to pass the store as a prop to TaskList, but you should import it at the TaskList file.

I just changed the README.md part where this information is wrong, hope that it makes sense.