### PR TITLE
Safer debug check

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -1,7 +1,7 @@
 const DEBUG_ON = 'on';
 const DEBUG_OFF = 'off';
 
-const isInBrowser = typeof window !== 'undefined';
+const isInBrowser = typeof window !== 'undefined' && window.localStorage !== 'undefined';
 
 let DEBUG = isInBrowser
   ? (window.localStorage.RECOLLECT__DEBUG || DEBUG_OFF)


### PR DESCRIPTION
Handling environments like JSDOM which have `window` but no `localStorage`