### PR TITLE
82 Fix component did update

### DIFF
--- a/src/collect.tsx
+++ b/src/collect.tsx
@@ -5,6 +5,10 @@ import state from './shared/state';
 import { debug } from './shared/debug';
 import { CollectorComponent, Store, WithStoreProp } from './shared/types';
 
+// As we render down into a tree of collected components, we will start/stop
+// recording
+const componentStack: CollectorComponent[] = [];
+
 const startRecordingGetsForComponent = (component: CollectorComponent) => {
   if (!state.isInBrowser) return;
 
@@ -15,6 +19,7 @@ const startRecordingGetsForComponent = (component: CollectorComponent) => {
   });
 
   state.currentComponent = component;
+  componentStack.push(state.currentComponent);
 };
 
 const stopRecordingGetsForComponent = () => {
@@ -24,7 +29,8 @@ const stopRecordingGetsForComponent = () => {
     console.groupEnd();
   });
 
-  state.currentComponent = null;
+  componentStack.pop();
+  state.currentComponent = componentStack[componentStack.length - 1] || null;
 };
 
 type RemoveStore<T> = Pick<T, Exclude<keyof T, keyof WithStoreProp>>;

--- a/src/shared/debug.ts
+++ b/src/shared/debug.ts
@@ -1,3 +1,8 @@
+import { CollectorComponent, Target } from './types';
+import * as paths from './paths';
+import * as utils from './utils';
+import state from './state';
+
 const DEBUG_ON = 'on';
 const DEBUG_OFF = 'off';
 
@@ -25,4 +30,43 @@ export const debugOff = () => {
 
 export const debug = (cb: () => void) => {
   if (DEBUG === DEBUG_ON) cb();
+};
+
+export const logGet = (target: Target, prop?: any, value?: any) => {
+  debug(() => {
+    console.groupCollapsed(`GET: ${paths.extendToUserString(target, prop)}`);
+    console.info(`Component: <${state.currentComponent!._name}>`);
+    if (typeof value !== 'undefined') {
+      console.info('Value:', value);
+    }
+    console.groupEnd();
+  });
+};
+
+export const logSet = (target: Target, prop: any, value?: any) => {
+  debug(() => {
+    console.groupCollapsed(`SET: ${paths.extendToUserString(target, prop)}`);
+    console.info('From:', utils.getValue(target, prop));
+    console.info('To:  ', value);
+    console.groupEnd();
+  });
+};
+
+export const logDelete = (target: Target, prop: any) => {
+  debug(() => {
+    console.groupCollapsed(`DELETE: ${paths.extendToUserString(target, prop)}`);
+    console.info('Property: ', paths.extendToUserString(target, prop));
+    console.groupEnd();
+  });
+};
+
+export const logUpdate = (
+  component: CollectorComponent,
+  propsUpdated: string[]
+) => {
+  debug(() => {
+    console.groupCollapsed(`UPDATE:  <${component._name}>`);
+    console.info('Changed properties:', propsUpdated);
+    console.groupEnd();
+  });
 };

--- a/src/updating.ts
+++ b/src/updating.ts
@@ -1,4 +1,4 @@
-import { debug } from './shared/debug';
+import { logUpdate } from './shared/debug';
 import state from './shared/state';
 import * as paths from './shared/paths';
 import * as utils from './shared/utils';
@@ -28,11 +28,7 @@ const flushUpdates = () => {
   queue.timeoutPending = false;
 
   queue.components.forEach((propsUpdated, component) => {
-    debug(() => {
-      console.groupCollapsed(`UPDATE:  <${component._name}>`);
-      console.info('Changed properties:', Array.from(propsUpdated));
-      console.groupEnd();
-    });
+    logUpdate(component, Array.from(propsUpdated));
 
     component.update();
   });
@@ -50,7 +46,6 @@ const flushUpdates = () => {
   queue.changedPaths.clear();
 
   state.proxyIsMuted = true;
-  // TODO (davidg): rename to prevStore/store
   utils.replaceObject(state.store, state.nextStore);
   state.proxyIsMuted = false;
 };


### PR DESCRIPTION
This keeps a stack of currently rendering components, so that when a child component has finished rendering, the 'current component' is set back to the parent component, rather than set to null.

This ensures that when the parent component fires `componentDidUpdate`, the `state.currentComponent` is correctly set to that component.