### PR TITLE
First attempt to fix types on unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ module.exports = {
     './jestSetup.js',
   ],
   clearMocks: true,
+  moduleNameMapper: {
+    'react-recollect': '<rootDir>/src/index.ts',
+  },
   modulePaths: ['<rootDir>/'],
   watchPathIgnorePatterns: [
     'node_modules/.cache', // don't listen to rollup-typescript cache

--- a/tests/react/componentDidUpdate.test.tsx
+++ b/tests/react/componentDidUpdate.test.tsx
@@ -1,8 +1,14 @@
 /* eslint-disable max-classes-per-file */
+
 import React, { Component, useEffect } from 'react';
 import { waitFor } from '@testing-library/react';
-import { collect, store as globalStore, initStore, WithStoreProp } from '../..';
 import * as testUtils from '../testUtils';
+import {
+  collect,
+  store as globalStore,
+  initStore,
+  WithStoreProp,
+} from 'react-recollect';
 
 interface Props extends WithStoreProp {
   reportUserChange: (comp: string, prev: number, next: number) => {};

--- a/tests/testUtils.tsx
+++ b/tests/testUtils.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
 import { render } from '@testing-library/react';
-import { collect, internals } from '..';
+import { collect, internals } from 'react-recollect';
 import * as paths from '../src/shared/paths';
 
 export const renderStrict = (children: React.ReactNode) => {
@@ -75,12 +75,13 @@ export type TaskType = {
   done?: boolean;
 };
 
-declare module '..' {
-  // Add a few things used in the tests
+declare module 'react-recollect' {
   interface Store {
-    tasks?: TaskType[];
-    // And anything else...
-    [key: string]: any;
+    userId: number;
+    loaded: boolean;
+    aProp: string;
+    aMap: Map<any, any>;
+    aSet: Set<any>;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "module": "CommonJS",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2017"
+    "target": "ES2017",
+    "baseUrl": ".",
+    "paths": {
+      "react-recollect": ["src/index.ts"],
+    }
   },
   "exclude": ["demo", "dist", "index.*.js"]
 }


### PR DESCRIPTION
Not sure if I'm missing something, but I wasn't able to run the unit tests.

I ran `npm install && npm run test` after forking and cloning the repo and got the following message.
_(this is just an example with one file to reduce the noise)_
```sh
tests/react/componentDidUpdate.test.tsx:4:73 - error TS7016: Could not find a declaration file for module '../..'. '/Users/sergio/dev/react-recollect/index.cjs.js' implicitly has an 'any' type.
```
I imagined it was a missing configuration since the tests are written in TypeScript and they are pointing to a JavaScript file, so I've added a module name mapper and pointed it to `src/index.ts` (See the changes in this PR).

After that, I ran `node_modules/.bin/jest tests/react/componentDidUpdate.test.tsx` and got the following message

```sh
    src/shared/state.ts:16:3 - error TS2739: Type '{}' is missing the following properties from type 'Store': userId, loaded, aProp, aMap, aSet

    16   store: {},
         ~~~~~

      src/shared/types.ts:45:3
        45   store: Store;
             ~~~~~
        The expected type comes from property 'store' which is declared here on type 'State'
```

I felt these were genuine errors as the store cannot be initialized as an empty object (according to the interface I created), but this was the given recommendation for using TypeScript with `recollect`. Or did I misunderstand something?


